### PR TITLE
멤버 브랜치 리펙토링

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/com/nhnacademy/booklay/server/controller/member/MemberController.java
+++ b/src/main/java/com/nhnacademy/booklay/server/controller/member/MemberController.java
@@ -5,7 +5,9 @@ import com.nhnacademy.booklay.server.dto.member.reponse.MemberRetrieveResponse;
 import com.nhnacademy.booklay.server.dto.member.request.MemberUpdateRequest;
 import com.nhnacademy.booklay.server.exception.category.ValidationFailedException;
 import com.nhnacademy.booklay.server.service.member.MemberService;
+
 import javax.validation.Valid;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -38,8 +40,7 @@ public class MemberController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public void createMember(@Valid @RequestBody MemberCreateRequest memberCreateRequest,
-                             BindingResult bindingResult) {
+    public void createMember(@Valid @RequestBody MemberCreateRequest memberCreateRequest, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
             throw new ValidationFailedException(bindingResult);
         }
@@ -48,9 +49,7 @@ public class MemberController {
 
     @PutMapping("/{memberNo}")
     @ResponseStatus(HttpStatus.ACCEPTED)
-    public void updateMember(@PathVariable Long memberNo,
-                             @Valid @RequestBody MemberUpdateRequest memberUpdateRequest,
-                             BindingResult bindingResult) {
+    public void updateMember(@PathVariable Long memberNo, @Valid @RequestBody MemberUpdateRequest memberUpdateRequest, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
             throw new ValidationFailedException(bindingResult);
         }

--- a/src/main/java/com/nhnacademy/booklay/server/controller/member/MemberController.java
+++ b/src/main/java/com/nhnacademy/booklay/server/controller/member/MemberController.java
@@ -44,25 +44,27 @@ public class MemberController {
     }
 
     @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<Void> createMember(@Valid @RequestBody MemberCreateRequest memberCreateRequest) {
 
         memberService.createMember(memberCreateRequest);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .build();
     }
 
     @PutMapping("/{memberNo}")
-    @ResponseStatus(HttpStatus.ACCEPTED)
-    public void updateMember(@PathVariable Long memberNo, @Valid @RequestBody MemberUpdateRequest memberUpdateRequest, BindingResult bindingResult) {
-        if (bindingResult.hasErrors()) {
-            throw new ValidationFailedException(bindingResult);
-        }
+    public ResponseEntity<Void> updateMember(@PathVariable Long memberNo, @Valid @RequestBody MemberUpdateRequest memberUpdateRequest) {
+
         memberService.updateMember(memberNo, memberUpdateRequest);
+        return ResponseEntity.status(HttpStatus.OK)
+                .build();
     }
 
     @DeleteMapping("/{memberNo}")
-    @ResponseStatus(HttpStatus.ACCEPTED)
-    public void deleteMember(@PathVariable Long memberNo) {
+    public ResponseEntity<Void> deleteMember(@PathVariable Long memberNo) {
+
         memberService.deleteMember(memberNo);
+        return ResponseEntity.status(HttpStatus.OK)
+                .build();
     }
 }
 

--- a/src/main/java/com/nhnacademy/booklay/server/controller/member/MemberController.java
+++ b/src/main/java/com/nhnacademy/booklay/server/controller/member/MemberController.java
@@ -1,9 +1,11 @@
 package com.nhnacademy.booklay.server.controller.member;
 
+import com.nhnacademy.booklay.server.dto.ErrorResponse;
 import com.nhnacademy.booklay.server.dto.member.request.MemberCreateRequest;
 import com.nhnacademy.booklay.server.dto.member.reponse.MemberRetrieveResponse;
 import com.nhnacademy.booklay.server.dto.member.request.MemberUpdateRequest;
 import com.nhnacademy.booklay.server.exception.category.ValidationFailedException;
+import com.nhnacademy.booklay.server.exception.member.MemberNotFoundException;
 import com.nhnacademy.booklay.server.service.member.MemberService;
 
 import javax.validation.Valid;
@@ -14,15 +16,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * @author 양승아
@@ -32,6 +26,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/members")
 @RequiredArgsConstructor
 public class MemberController {
+    private static final String ERROR_CODE = "MemberNotFound";
+
     private final MemberService memberService;
 
     @GetMapping("/{memberNo}")
@@ -65,6 +61,12 @@ public class MemberController {
         memberService.deleteMember(memberNo);
         return ResponseEntity.status(HttpStatus.OK)
                 .build();
+    }
+
+    @ExceptionHandler(MemberNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFoundException(MemberNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ErrorResponse.builder().code(ERROR_CODE).message(ex.getMessage()).build());
     }
 }
 

--- a/src/main/java/com/nhnacademy/booklay/server/controller/member/MemberController.java
+++ b/src/main/java/com/nhnacademy/booklay/server/controller/member/MemberController.java
@@ -11,6 +11,8 @@ import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,17 +35,18 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping("/{memberNo}")
-    @ResponseStatus(HttpStatus.OK)
-    public MemberRetrieveResponse retrieveMember(@PathVariable Long memberNo) {
-        return memberService.retrieveMember(memberNo);
+    public ResponseEntity<MemberRetrieveResponse> retrieveMember(@PathVariable Long memberNo) {
+
+        MemberRetrieveResponse memberResponse = memberService.retrieveMember(memberNo);
+        return ResponseEntity.status(HttpStatus.OK)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(memberResponse);
     }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public void createMember(@Valid @RequestBody MemberCreateRequest memberCreateRequest, BindingResult bindingResult) {
-        if (bindingResult.hasErrors()) {
-            throw new ValidationFailedException(bindingResult);
-        }
+    public ResponseEntity<Void> createMember(@Valid @RequestBody MemberCreateRequest memberCreateRequest) {
+
         memberService.createMember(memberCreateRequest);
     }
 

--- a/src/main/java/com/nhnacademy/booklay/server/dto/ErrorResponse.java
+++ b/src/main/java/com/nhnacademy/booklay/server/dto/ErrorResponse.java
@@ -1,0 +1,37 @@
+package com.nhnacademy.booklay.server.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class ErrorResponse {
+
+    private final String code;
+    private final String message;
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final List<ValidationError> errors;
+
+    @Getter
+    @Builder
+    @RequiredArgsConstructor
+    public static class ValidationError {
+
+        private final String field;
+        private final String message;
+
+        public static ValidationError of(final FieldError fieldError) {
+            return ValidationError.builder()
+                    .field(fieldError.getField())
+                    .message(fieldError.getDefaultMessage())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/nhnacademy/booklay/server/dto/member/request/MemberCreateRequest.java
+++ b/src/main/java/com/nhnacademy/booklay/server/dto/member/request/MemberCreateRequest.java
@@ -18,25 +18,33 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class MemberCreateRequest {
+
     @NotBlank
     private String gender;
+
     @NotBlank
     private String memberId;
+
     @NotBlank
     private String password;
+
     @NotBlank
     private String nickname;
+
     @NotBlank
     private String name;
+
     @NotNull
-    @JsonSerialize(using = LocalDateSerializer.class)
     @JsonDeserialize(using = LocalDateDeserializer.class)
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    @JsonSerialize(using = LocalDateSerializer.class)
+    @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate birthday;
+
     @NotBlank
     private String phoneNo;
+
     @Email
     @NotBlank
     private String email;

--- a/src/main/java/com/nhnacademy/booklay/server/dto/member/request/MemberUpdateRequest.java
+++ b/src/main/java/com/nhnacademy/booklay/server/dto/member/request/MemberUpdateRequest.java
@@ -12,6 +12,7 @@ import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 @Getter
 @AllArgsConstructor
@@ -35,4 +36,5 @@ public class MemberUpdateRequest {
     @Email
     @NotBlank
     private String email;
+
 }

--- a/src/main/java/com/nhnacademy/booklay/server/dto/member/request/MemberUpdateRequest.java
+++ b/src/main/java/com/nhnacademy/booklay/server/dto/member/request/MemberUpdateRequest.java
@@ -15,7 +15,6 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
 public class MemberUpdateRequest {
     @NotBlank
@@ -29,7 +28,7 @@ public class MemberUpdateRequest {
     @NotNull
     @JsonSerialize(using = LocalDateSerializer.class)
     @JsonDeserialize(using = LocalDateDeserializer.class)
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate birthday;
     @NotBlank
     private String phoneNo;

--- a/src/main/java/com/nhnacademy/booklay/server/entity/Member.java
+++ b/src/main/java/com/nhnacademy/booklay/server/entity/Member.java
@@ -1,6 +1,7 @@
 package com.nhnacademy.booklay.server.entity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.nhnacademy.booklay.server.dto.member.request.MemberUpdateRequest;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -62,6 +63,7 @@ public class Member {
     private LocalDateTime deletedAt;
 
     @Column(name = "is_blocked")
+    @Setter
     private Boolean isBlocked;
 
     @Builder
@@ -77,14 +79,13 @@ public class Member {
         this.isBlocked = isBlocked;
     }
 
-    public void update(Gender gender, String password, String nickname, String name, LocalDate birthday, String phoneNo, String email, Boolean isBlocked) {
+    public void updateMember(MemberUpdateRequest request, Gender gender) {
         this.gender = gender;
-        this.password = password;
-        this.nickname = nickname;
-        this.name = name;
-        this.birthday = birthday;
-        this.phoneNo = phoneNo;
-        this.email = email;
-        this.isBlocked = isBlocked;
+        this.password = request.getPassword();
+        this.nickname = request.getNickname();
+        this.name = request.getName();
+        this.birthday = request.getBirthday();
+        this.phoneNo = request.getPhoneNo();
+        this.email = request.getEmail();
     }
 }

--- a/src/main/java/com/nhnacademy/booklay/server/exception/ApiException.java
+++ b/src/main/java/com/nhnacademy/booklay/server/exception/ApiException.java
@@ -1,0 +1,11 @@
+package com.nhnacademy.booklay.server.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ApiException extends RuntimeException{
+
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/nhnacademy/booklay/server/exception/CommonErrorCode.java
+++ b/src/main/java/com/nhnacademy/booklay/server/exception/CommonErrorCode.java
@@ -1,0 +1,18 @@
+package com.nhnacademy.booklay.server.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode{
+
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid parameter included"),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Resource not exists"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/nhnacademy/booklay/server/exception/ErrorCode.java
+++ b/src/main/java/com/nhnacademy/booklay/server/exception/ErrorCode.java
@@ -1,0 +1,11 @@
+package com.nhnacademy.booklay.server.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+    String name();
+    HttpStatus getHttpStatus();
+    String getMessage();
+
+}

--- a/src/main/java/com/nhnacademy/booklay/server/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/nhnacademy/booklay/server/service/member/MemberServiceImpl.java
@@ -18,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 
 /**
  * @author 양승아
@@ -68,4 +69,5 @@ public class MemberServiceImpl implements MemberService {
         Member member = memberRepository.findByMemberNo(memberNo).orElseThrow(() -> new MemberNotFoundException(memberNo));
         member.setDeletedAt(LocalDateTime.now());
     }
+
 }

--- a/src/main/java/com/nhnacademy/booklay/server/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/nhnacademy/booklay/server/service/member/MemberServiceImpl.java
@@ -5,15 +5,14 @@ import com.nhnacademy.booklay.server.dto.member.request.MemberCreateRequest;
 import com.nhnacademy.booklay.server.dto.member.request.MemberUpdateRequest;
 import com.nhnacademy.booklay.server.entity.Gender;
 import com.nhnacademy.booklay.server.entity.Member;
-import com.nhnacademy.booklay.server.exception.member.CreateMemberFailedException;
 import com.nhnacademy.booklay.server.exception.member.GenderNotFoundException;
-import com.nhnacademy.booklay.server.exception.member.MemberAlreadyExistedException;
 import com.nhnacademy.booklay.server.exception.member.MemberNotFoundException;
-import com.nhnacademy.booklay.server.exception.member.UpdateMemberFailedException;
 import com.nhnacademy.booklay.server.repository.GenderRepository;
 import com.nhnacademy.booklay.server.repository.MemberRepository;
+
 import java.time.LocalDateTime;
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -28,14 +27,21 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
+
     private final MemberRepository memberRepository;
     private final GenderRepository genderRepository;
 
     @Override
+    public void createMember(MemberCreateRequest createDto) {
+        Gender gender = genderRepository.findByName(createDto.getGender()).orElseThrow(() -> new GenderNotFoundException(createDto.getGender()));
+
+        memberRepository.save(createDto.toEntity(gender));
+    }
+
+    @Override
     @Transactional(readOnly = true)
     public MemberRetrieveResponse retrieveMember(Long memberNo) {
-        Member member = memberRepository.findByMemberNo(memberNo)
-            .orElseThrow(() -> new MemberNotFoundException(memberNo));
+        Member member = memberRepository.findByMemberNo(memberNo).orElseThrow(() -> new MemberNotFoundException(memberNo));
 
         return MemberRetrieveResponse.fromEntity(member);
     }
@@ -47,45 +53,19 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public void createMember(MemberCreateRequest createDto) {
-        if (!memberRepository.existsByMemberId(createDto.getMemberId())) {
-            try {
-                Gender gender = genderRepository.findByName(createDto.getGender())
-                    .orElseThrow(() -> new GenderNotFoundException(createDto.getGender()));
-                memberRepository.save(createDto.toEntity(gender));
-            } catch (GenderNotFoundException e) {
-                throw new CreateMemberFailedException(createDto.getMemberId());
-            }
-        } else {
-            throw new MemberAlreadyExistedException(createDto.getMemberId());
-        }
-    }
-
-    @Override
     public void updateMember(Long memberNo, MemberUpdateRequest updateDto) {
-        try {
-            Gender gender = genderRepository.findByName(updateDto.getGender())
-                .orElseThrow(() -> new GenderNotFoundException(updateDto.getGender()));
-            Member member = memberRepository.findByMemberNo(memberNo)
-                .orElseThrow(() -> new MemberNotFoundException(memberNo));
-            member.update(
-                gender,
-                updateDto.getPassword(),
-                updateDto.getNickname(),
-                updateDto.getName(),
-                updateDto.getBirthday(),
-                updateDto.getPhoneNo(),
-                updateDto.getEmail(),
-                member.getIsBlocked());
-        } catch (Exception e) {
-            throw new UpdateMemberFailedException(memberNo);
-        }
+
+        Member member = memberRepository.findById(memberNo).orElseThrow(() -> new MemberNotFoundException(memberNo));
+        Gender gender = genderRepository.findByName(updateDto.getName()).orElseThrow(() -> new GenderNotFoundException(updateDto.getName()));
+
+        member.updateMember(updateDto, gender);
+        memberRepository.save(member);
+
     }
 
     @Override
     public void deleteMember(Long memberNo) {
-            Member member = memberRepository.findByMemberNo(memberNo)
-                .orElseThrow(() -> new MemberNotFoundException(memberNo));
-            member.setDeletedAt(LocalDateTime.now());
+        Member member = memberRepository.findByMemberNo(memberNo).orElseThrow(() -> new MemberNotFoundException(memberNo));
+        member.setDeletedAt(LocalDateTime.now());
     }
 }

--- a/src/test/java/com/nhnacademy/booklay/server/dummy/Dummy.java
+++ b/src/test/java/com/nhnacademy/booklay/server/dummy/Dummy.java
@@ -1,5 +1,7 @@
 package com.nhnacademy.booklay.server.dummy;
 
+import com.nhnacademy.booklay.server.dto.member.request.MemberCreateRequest;
+import com.nhnacademy.booklay.server.dto.member.request.MemberUpdateRequest;
 import com.nhnacademy.booklay.server.entity.Authority;
 import com.nhnacademy.booklay.server.entity.Category;
 import com.nhnacademy.booklay.server.entity.Coupon;
@@ -184,5 +186,32 @@ public class Dummy {
             .id(1L)
             .name("입금대기중")
             .build();
+    }
+
+    public static MemberCreateRequest getDummyMemberCreateRequest() {
+        MemberCreateRequest memberRequest = new MemberCreateRequest();
+        ReflectionTestUtils.setField(memberRequest, "gender", "M");
+        ReflectionTestUtils.setField(memberRequest, "memberId", "HoDong");
+        ReflectionTestUtils.setField(memberRequest, "password", "$2a$12$5KoVJnK1WF2h4h4T3FmifeO3ZLtAjiayJ783EfvTs7zSIz2GUhnMu");
+        ReflectionTestUtils.setField(memberRequest, "nickname", "천하장사");
+        ReflectionTestUtils.setField(memberRequest, "name", "강호동");
+        ReflectionTestUtils.setField(memberRequest, "birthday", LocalDate.now());
+        ReflectionTestUtils.setField(memberRequest, "phoneNo", "01012341234");
+        ReflectionTestUtils.setField(memberRequest, "email", "aaaa@gmail.com");
+
+        return memberRequest;
+    }
+
+    public static MemberUpdateRequest getDummyMemberUpdateRequest() {
+        MemberUpdateRequest memberRequest = new MemberUpdateRequest();
+        ReflectionTestUtils.setField(memberRequest, "gender", "M");
+        ReflectionTestUtils.setField(memberRequest, "password", "$2a$12$5KoVJnK1WF2h4h4T3FmifeO3ZLtAjiayJ783EfvTs7zSIz2GUhnMu");
+        ReflectionTestUtils.setField(memberRequest, "nickname", "천하장사123");
+        ReflectionTestUtils.setField(memberRequest, "name", "강호동123");
+        ReflectionTestUtils.setField(memberRequest, "birthday", LocalDate.now());
+        ReflectionTestUtils.setField(memberRequest, "phoneNo", "01033333333");
+        ReflectionTestUtils.setField(memberRequest, "email", "bbbb@gmail.com");
+
+        return memberRequest;
     }
 }


### PR DESCRIPTION
## 작업내역

### Exception 처리방식 리펙터링
- Validation Exception의 경우 Web Controller Advice에서, 개별 도메인 Exception의 경우 컨트롤러 내부에서 @ExceptionHandler사용
- 참고: https://mangkyu.tistory.com/204

### MemberService 리펙토링
- 복잡한 로직 단순화.
  - 코드는 단순, 명확하게 작성하는것을 지향합니다.
- DTO에 있던 불필요한 AllArgsConstructor 변경 -> 테스트코드에선 Dummy에서 ReflectionTestUtils를 통해 생성

### MemberController 리펙토링
- @ResponseStatus제거 -> ResponseEntity로 변경
- 참고: https://dev-splin.github.io/spring/Spring-ResponseEntity/

### ControllerTest 리펙토링
- given, when, then 에 맞는 BDDMockito사용
- createDto, updateDto 더미로 변경
- 수정내역
  - 조회, 조회 실패, 회원등록 성공, 회원수정 성공, 회원수정 실패


### 테스트 예시 보고 수정해보세요
- 회원 삭제 성공 테스트, 회원 삭제 실패 테스트 

Service Test는 내일 만들겠습니다